### PR TITLE
org migration

### DIFF
--- a/BaselineOfSystemCommands.package/BaselineOfSystemCommands.class/instance/baseline..st
+++ b/BaselineOfSystemCommands.package/BaselineOfSystemCommands.class/instance/baseline..st
@@ -4,7 +4,7 @@ baseline: spec
 
 	spec for: #'common' do: [
 		spec baseline: 'Commander' with: [
-				spec repository: 'github://dionisiydk/Commander:v0.6.x' ].
+				spec repository: 'github://pharo-ide/Commander:v0.6.x' ].
 		spec
 			package: #'SystemCommands-RefactoringSupport' with: [
 				spec requires: #('Commander' ). ]; 


### PR DESCRIPTION
fix baseline to point to the new repo under pharo-ide org