### PR TITLE
fix for extract method

### DIFF
--- a/src/SystemCommands-SourceCodeCommands/SycExtractMethodCommand.class.st
+++ b/src/SystemCommands-SourceCodeCommands/SycExtractMethodCommand.class.st
@@ -31,6 +31,8 @@ SycExtractMethodCommand >> execute [
 		extract: selectedInterval
 		from: method selector
 		in: method origin.
+	(NautilusRefactoring onEnvironment: method class environment)
+		refactoringOptions: refactoring.
 	refactoring setOption: #methodName toUse:  [ :ref :methodName |
 		dialog := SycMethodNameEditor openOn: methodName.
 		dialog cancelled ifTrue: [  CmdCommandAborted signal ].


### PR DESCRIPTION
fix for https://pharo.fogbugz.com/f/cases/22319/Extracting-an-already-existing-method-should-not-raise-an-error.
WARNiNG: do not merge before https://github.com/pharo-project/pharo/pull/1940 is integrated