### PR TITLE
Fix for extract method without NautilusRefactoring

### DIFF
--- a/src/SystemCommands-SourceCodeCommands/SycExtractMethodCommand.class.st
+++ b/src/SystemCommands-SourceCodeCommands/SycExtractMethodCommand.class.st
@@ -28,9 +28,9 @@ SycExtractMethodCommand >> execute [
 	selectedInterval := selectedTextInterval ifEmpty: [ sourceNode sourceInterval ].
 	
 	refactoring := RBExtractMethodRefactoring	
-		extract: selectedInterval
-		from: method selector
-		in: method origin.
+		extract: selectedInterval from: method selector in: method origin.
+	self setUpOptionToUseExistingMethodDuring: refactoring.
+	self setUpOptionToOverrideExistingMethodDuring: refactoring.
 	refactoring setOption: #methodName toUse:  [ :ref :methodName |
 		dialog := SycMethodNameEditor openOn: methodName.
 		dialog cancelled ifTrue: [  CmdCommandAborted signal ].
@@ -44,4 +44,21 @@ SycExtractMethodCommand >> readParametersFromContext: aSourceCodeContext [
 	super readParametersFromContext: aSourceCodeContext.
 	
 	selectedTextInterval := aSourceCodeContext selectedTextInterval
+]
+
+{ #category : #execution }
+SycExtractMethodCommand >> setUpOptionToOverrideExistingMethodDuring: aRefactoring [
+
+	aRefactoring setOption: #alreadyDefined toUse:  [ :ref :class :selector | 
+		ref refactoringWarning: 'Method ', selector printString, ' will override method in ', class name]. 
+]
+
+{ #category : #execution }
+SycExtractMethodCommand >> setUpOptionToUseExistingMethodDuring: aRefactoring [
+
+	aRefactoring setOption: #useExistingMethod toUse:  [ :ref :selector | 
+		UIManager default 
+			confirm: 'Do you want use existing method ', selector printString, '?'
+			label: 'Warninig']. 	
+	
 ]


### PR DESCRIPTION
It adds refactoring options for two cases: 
- when extracted code is already existing method
- when extracted method will override existing method
It seems the only options required to handle extract method failures. So it does not requires NautilusRefactoring and outdates PR #44.Override option relies on RefactoringWarning handling which is done in #46