### PR TITLE
Still bad refactoring failures

### DIFF
--- a/src/SystemCommands-ClassCommands/SycRemoveClassCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycRemoveClassCommand.class.st
@@ -33,3 +33,12 @@ SycRemoveClassCommand >> execute [
 SycRemoveClassCommand >> isComplexRefactoring [
 	^true
 ]
+
+{ #category : #execution }
+SycRemoveClassCommand >> prepareFullExecutionInContext: aToolContext [
+	| noUsers |
+	super prepareFullExecutionInContext: aToolContext.
+	
+	noUsers := aToolContext confirmUnusedClasses: classes.
+	noUsers ifFalse: [ CmdCommandAborted signal ]
+]

--- a/src/SystemCommands-RefactoringSupport/RBRefactoringError.extension.st
+++ b/src/SystemCommands-RefactoringSupport/RBRefactoringError.extension.st
@@ -7,10 +7,12 @@ RBRefactoringError >> notifyUserOfCommand: aCommand [
 	title := self actionBlock isNotNil
 		ifTrue: [ 'Warning' ] ifFalse: [ 'Warning. Want to proceed?' ].
 
-	answer := (UIManager default confirm: self messageText label: title) = true.
+	answer := UIManager default confirm: self messageText label: title. 
 
-	self actionBlock 
-		ifNotNil: [ answer ifTrue: [ self actionBlock value ] ].
-
-	self resume: answer	
+	answer ifTrue: [ 
+		"Existing actionBlock means that there is already defined handled of refactoring error.
+		We should not resume in that case. Otherwise user can resume by his own risk"
+		self actionBlock 
+			ifNil: [ self resume: true ] 
+			ifNotNil: #value]
 ]

--- a/src/SystemCommands-RefactoringSupport/RBRemoveClassRefactoring.extension.st
+++ b/src/SystemCommands-RefactoringSupport/RBRemoveClassRefactoring.extension.st
@@ -1,7 +1,0 @@
-Extension { #name : #RBRemoveClassRefactoring }
-
-{ #category : #'*SystemCommands-RefactoringSupport' }
-RBRemoveClassRefactoring >> classes [
-	
-	^ classNames collect: [ :e | (model classNamed: e) realClass ]
-]

--- a/src/SystemCommands-RefactoringSupport/SycRefactoringPreview.class.st
+++ b/src/SystemCommands-RefactoringSupport/SycRefactoringPreview.class.st
@@ -165,14 +165,8 @@ SycRefactoringPreview >> command: aCommand [
 SycRefactoringPreview >> generateChanges [
 
 	| rbEnvironment |
-	
-	changes ifNotNil: [ ^ changes ].
-	
 	changes := command asRefactorings.
 	rbEnvironment := self activeRBEnvironment.
-
-	changes do: [ :aChange | self prepareOptions: aChange ].
-
 	changes do: [ :each | 
 		each model environment: rbEnvironment.
 		each primitiveExecute ]
@@ -250,13 +244,6 @@ SycRefactoringPreview >> pickedChanges [
 	| selectedItems |
 	selectedItems := changesTree selectedItems collect: #content.
 	^ changesTree roots select: [ :i | selectedItems includes: i ]
-]
-
-{ #category : #'private - changes' }
-SycRefactoringPreview >> prepareOptions: aRefactoring [ 
-
-	aRefactoring setOption: #openBrowser toUse: [ :aRefactor :anEnvironment |
-		ClyQueryBrowser openOn: (ClyClassReferences toAny: aRefactor classes)]
 ]
 
 { #category : #accessing }

--- a/src/SystemCommands-VariableCommands/SycPushDownVariableCommand.class.st
+++ b/src/SystemCommands-VariableCommands/SycPushDownVariableCommand.class.st
@@ -18,3 +18,12 @@ SycPushDownVariableCommand >> asRefactorings [
 SycPushDownVariableCommand >> defaultMenuItemName [
 	^'Push down'
 ]
+
+{ #category : #execution }
+SycPushDownVariableCommand >> prepareFullExecutionInContext: aToolContext [
+	| noUsers |
+	super prepareFullExecutionInContext: aToolContext.
+	
+	noUsers := aToolContext confirmUnusedVariables: variables.
+	noUsers ifFalse: [ CmdCommandAborted signal ]
+]

--- a/src/SystemCommands-VariableCommands/SycPushDownVariableCommand.class.st
+++ b/src/SystemCommands-VariableCommands/SycPushDownVariableCommand.class.st
@@ -24,6 +24,6 @@ SycPushDownVariableCommand >> prepareFullExecutionInContext: aToolContext [
 	| noUsers |
 	super prepareFullExecutionInContext: aToolContext.
 	
-	noUsers := aToolContext confirmUnusedVariables: variables.
+	noUsers := aToolContext confirmUnusedVariablesInDefiningClass: variables.
 	noUsers ifFalse: [ CmdCommandAborted signal ]
 ]

--- a/src/SystemCommands-VariableCommands/SycRemoveVariableCommand.class.st
+++ b/src/SystemCommands-VariableCommands/SycRemoveVariableCommand.class.st
@@ -31,9 +31,9 @@ SycRemoveVariableCommand >> isComplexRefactoring [
 
 { #category : #execution }
 SycRemoveVariableCommand >> prepareFullExecutionInContext: aToolContext [
-	| answer |
+	| noUsers |
 	super prepareFullExecutionInContext: aToolContext.
 
-	answer := aToolContext confirmVariableRemoveFor: variables.
-	answer ifFalse: [CmdCommandAborted signal]
+	noUsers := aToolContext confirmUnusedVariables: variables.
+	noUsers ifFalse: [CmdCommandAborted signal]
 ]


### PR DESCRIPTION
#55:
Explicit logic to check unused classes and variables instead of relying on openBrowser option of RB engine:
- aToolContext confirmUnusedClasses: classes
- aToolContext confirmUnusedVariables: variables
- aToolContext confirmUnusedVariablesInDefiningClass: variables

It fixes dependency issue: this project should not depends on Calypso. System commands are supposed to be reusable by other tools