### PR TITLE
issue/errorHandlingInSourceRefactoring

### DIFF
--- a/src/BaselineOfSystemCommands/BaselineOfSystemCommands.class.st
+++ b/src/BaselineOfSystemCommands/BaselineOfSystemCommands.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #BaselineOfSystemCommands,
 	#superclass : #BaselineOf,
-	#category : 'BaselineOfSystemCommands'
+	#category : #BaselineOfSystemCommands
 }
 
 { #category : #baselines }
@@ -10,7 +10,7 @@ BaselineOfSystemCommands >> baseline: spec [
 
 	spec for: #'common' do: [
 		spec baseline: 'Commander' with: [
-			spec repository: 'github://pharo-ide/Commander:v0.7.x/src' ].
+			spec repository: 'github://pharo-ide/Commander:v0.7.2/src' ].
 		spec
 			package: #'SystemCommands-RefactoringSupport' with: [
 				spec requires: #('Commander' ). ]; 

--- a/src/SystemCommands-SourceCodeCommands/SycExtractMethodCommand.class.st
+++ b/src/SystemCommands-SourceCodeCommands/SycExtractMethodCommand.class.st
@@ -36,7 +36,7 @@ SycExtractMethodCommand >> execute [
 		dialog cancelled ifTrue: [  CmdCommandAborted signal ].
 		methodName].
 	
-	refactoring execute
+	self executeRefactoring: refactoring.
 ]
 
 { #category : #execution }

--- a/src/SystemCommands-SourceCodeCommands/SycExtractTempCommand.class.st
+++ b/src/SystemCommands-SourceCodeCommands/SycExtractTempCommand.class.st
@@ -44,7 +44,7 @@ SycExtractTempCommand >> execute [
 		from: method selector
 		in: method origin.
 	
-	refactoring execute
+	self executeRefactoring: refactoring.
 ]
 
 { #category : #execution }

--- a/src/SystemCommands-SourceCodeCommands/SycInlineMethodCommand.class.st
+++ b/src/SystemCommands-SourceCodeCommands/SycInlineMethodCommand.class.st
@@ -27,5 +27,5 @@ SycInlineMethodCommand >> execute [
 		inMethod: method selector
 		forClass: method origin.
 	
-	refactoring execute
+	self executeRefactoring: refactoring.
 ]

--- a/src/SystemCommands-SourceCodeCommands/SycInlineTempCommand.class.st
+++ b/src/SystemCommands-SourceCodeCommands/SycInlineTempCommand.class.st
@@ -29,5 +29,6 @@ SycInlineTempCommand >> execute [
 		inline: assignment sourceInterval
 		from: method selector
 		in: method origin.
-	refactoring execute
+
+	self executeRefactoring: refactoring.
 ]

--- a/src/SystemCommands-SourceCodeCommands/SycRenameTempCommand.class.st
+++ b/src/SystemCommands-SourceCodeCommands/SycRenameTempCommand.class.st
@@ -43,7 +43,7 @@ SycRenameTempCommand >> execute [
 		in: method origin
 		selector: method selector.
 	
-	refactoring execute
+	self executeRefactoring: refactoring.
 ]
 
 { #category : #execution }

--- a/src/SystemCommands-SourceCodeCommands/SycSourceCodeCommand.class.st
+++ b/src/SystemCommands-SourceCodeCommands/SycSourceCodeCommand.class.st
@@ -24,6 +24,13 @@ SycSourceCodeCommand class >> method: aMethod node: aRBProgramNode [
 		sourceNode: aRBProgramNode
 ]
 
+{ #category : #private }
+SycSourceCodeCommand >> executeRefactoring: refactoring [
+
+	NautilusRefactoring new refactoringOptions: refactoring.
+	[ refactoring execute ] on: RBRefactoringError do: [ :e | UIManager default alert: e messageText ].
+]
+
 { #category : #accessing }
 SycSourceCodeCommand >> method [
 	^ method


### PR DESCRIPTION
Baseline should use the correct dependency. If not when releasing the version is invalid and should be touched in master directlty.https://github.com/pharo-ide/Calypso/issues/415