### PR TITLE
60-Unecessary-dialogs-during-rename

### DIFF
--- a/src/SystemCommands-RefactoringSupport/SycRefactoringPreview.class.st
+++ b/src/SystemCommands-RefactoringSupport/SycRefactoringPreview.class.st
@@ -259,8 +259,7 @@ SycRefactoringPreview >> scopes [
 { #category : #accessing }
 SycRefactoringPreview >> scopes: anObject [
 	scopes := anObject.
-	scopeDropList items: scopes.
-	scopeDropList setIndex: 1
+	scopeDropList items: scopes "It also sets up first item as selection"
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
#60: avoid double seletion changes during drop list initialization