### PR TITLE
improveClassRemoveCommand

### DIFF
--- a/src/SystemCommands-ClassCommands/SycRemoveClassCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycRemoveClassCommand.class.st
@@ -13,6 +13,19 @@ SycRemoveClassCommand >> asRefactorings [
 	^{RBRemoveClassRefactoring classNames: (classes collect: #name)}
 ]
 
+{ #category : #execution }
+SycRemoveClassCommand >> confirmRefactoringInContext: aToolContext by: aCommandActivator [
+	"All refactoring errors here are related to existance of removed class users.
+	All these cases are handled on the level of #confirmUnusedClasses
+	and here we need to ignore RB signals.
+	Notice that existing logic of RB engine for class removal 
+	does not allow correctly handle class users like show them in browser 
+	because there is no information about kind of users in #openBrowser option"
+	
+	[super confirmRefactoringInContext: aToolContext by: aCommandActivator ]
+		on: RBRefactoringError do: [ :err | err resume: true ]
+]
+
 { #category : #accessing }
 SycRemoveClassCommand >> defaultMenuIconName [
 	^#removeIcon
@@ -36,9 +49,11 @@ SycRemoveClassCommand >> isComplexRefactoring [
 
 { #category : #execution }
 SycRemoveClassCommand >> prepareFullExecutionInContext: aToolContext [
-	| noUsers |
+	| noUsers answer |
 	super prepareFullExecutionInContext: aToolContext.
 	
 	noUsers := aToolContext confirmUnusedClasses: classes.
-	noUsers ifFalse: [ CmdCommandAborted signal ]
+	noUsers ifFalse: [ 
+		answer := UIManager default confirm: 'Do you want to remove anyway?'.
+		answer ifFalse: [ 	CmdCommandAborted signal ]]
 ]


### PR DESCRIPTION
Allow user continue class removal even when class has any kind of users.It is based on little hack to ignore RB warnings about class users. It assumes that context logic #confirmUnusedClasses will do all required warnings to notify user. And Calypso will do it.Using RB engine itself is complecated because it uses single  #openBrowser option for any kind of class users