### PR TITLE
explicitIsAbstract

### DIFF
--- a/src/SystemCommands-ClassCommands/SycClassCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycClassCommand.class.st
@@ -20,6 +20,11 @@ SycClassCommand class >> canBeExecutedInContext: aToolContext [
 	^aToolContext isClassSelected
 ]
 
+{ #category : #testing }
+SycClassCommand class >> isAbstract [
+	^self = SycClassCommand 
+]
+
 { #category : #accessing }
 SycClassCommand >> classes [
 	^ classes

--- a/src/SystemCommands-ClassCommands/SycNewClassCreationCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycNewClassCreationCommand.class.st
@@ -16,6 +16,11 @@ Class {
 	#category : #'SystemCommands-ClassCommands'
 }
 
+{ #category : #testing }
+SycNewClassCreationCommand class >> isAbstract [
+	^self = SycNewClassCreationCommand 
+]
+
 { #category : #execution }
 SycNewClassCreationCommand >> applyResultInContext: aToolContext [
 	

--- a/src/SystemCommands-ClassCommands/SycSingleClassCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycSingleClassCommand.class.st
@@ -20,6 +20,11 @@ SycSingleClassCommand class >> canBeExecutedInContext: aToolContext [
 	^aToolContext isClassSelected 
 ]
 
+{ #category : #testing }
+SycSingleClassCommand class >> isAbstract [
+	^self = SycSingleClassCommand 
+]
+
 { #category : #execution }
 SycSingleClassCommand >> prepareFullExecutionInContext: aToolContext [
 	super prepareFullExecutionInContext: aToolContext.

--- a/src/SystemCommands-MessageCommands/SycChangeMessageSignatureCommand.class.st
+++ b/src/SystemCommands-MessageCommands/SycChangeMessageSignatureCommand.class.st
@@ -28,6 +28,11 @@ SycChangeMessageSignatureCommand class >> canBeExecutedInContext: aToolContext [
 	^aToolContext isMessageSelected | aToolContext isMethodSelected
 ]
 
+{ #category : #testing }
+SycChangeMessageSignatureCommand class >> isAbstract [
+	^self = SycChangeMessageSignatureCommand 
+]
+
 { #category : #execution }
 SycChangeMessageSignatureCommand >> applyResultInContext: aToolContext [
 	super applyResultInContext: aToolContext.

--- a/src/SystemCommands-MessageCommands/SycMessageCommand.class.st
+++ b/src/SystemCommands-MessageCommands/SycMessageCommand.class.st
@@ -34,6 +34,11 @@ SycMessageCommand class >> forMethods: methods [
 	^self for: (methods collect: [:each | SycMessageDescription ofMethod: each])
 ]
 
+{ #category : #testing }
+SycMessageCommand class >> isAbstract [
+	^self = SycMessageCommand
+]
+
 { #category : #accessing }
 SycMessageCommand >> messages [
 	^ messages

--- a/src/SystemCommands-MethodCommands/SycMethodCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycMethodCommand.class.st
@@ -26,6 +26,11 @@ SycMethodCommand class >> for: methods [
 		methods: methods
 ]
 
+{ #category : #testing }
+SycMethodCommand class >> isAbstract [
+	^self = SycMethodCommand 
+]
+
 { #category : #accessing }
 SycMethodCommand >> methods [
 	^ methods

--- a/src/SystemCommands-MethodCommands/SycMethodRepackagingCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycMethodRepackagingCommand.class.st
@@ -13,6 +13,11 @@ Class {
 	#category : #'SystemCommands-MethodCommands'
 }
 
+{ #category : #testing }
+SycMethodRepackagingCommand class >> isAbstract [
+	^self = SycMethodRepackagingCommand 
+]
+
 { #category : #execution }
 SycMethodRepackagingCommand >> moveMethod: aMethod toPackage: aPackage [
 	| existingPackage wasExtension willBeExtension |

--- a/src/SystemCommands-PackageCommands/SycPackageCommand.class.st
+++ b/src/SystemCommands-PackageCommands/SycPackageCommand.class.st
@@ -20,6 +20,11 @@ SycPackageCommand class >> canBeExecutedInContext: aToolContext [
 	^aToolContext isPackageSelected
 ]
 
+{ #category : #testing }
+SycPackageCommand class >> isAbstract [
+	^self = SycPackageCommand 
+]
+
 { #category : #accessing }
 SycPackageCommand >> packages [
 	^ packages

--- a/src/SystemCommands-SourceCodeCommands/SycSourceCodeCommand.class.st
+++ b/src/SystemCommands-SourceCodeCommands/SycSourceCodeCommand.class.st
@@ -17,6 +17,11 @@ Class {
 	#category : #'SystemCommands-SourceCodeCommands'
 }
 
+{ #category : #testing }
+SycSourceCodeCommand class >> isAbstract [
+	^self = SycSourceCodeCommand 
+]
+
 { #category : #'instance creation' }
 SycSourceCodeCommand class >> method: aMethod node: aRBProgramNode [
 	^self new 

--- a/src/SystemCommands-VariableCommands/SycRefactorVariableCommand.class.st
+++ b/src/SystemCommands-VariableCommands/SycRefactorVariableCommand.class.st
@@ -26,6 +26,11 @@ SycRefactorVariableCommand class >> canBeExecutedInContext: aToolContext [
 		and: [ aToolContext isGlobalVariableSelected not ]
 ]
 
+{ #category : #testing }
+SycRefactorVariableCommand class >> isAbstract [
+	^self = SycRefactorVariableCommand 
+]
+
 { #category : #execution }
 SycRefactorVariableCommand >> createRefactorings: variableRefactoringClass [
 	^self createRefactorings: variableRefactoringClass using: [ ]

--- a/src/SystemCommands-VariableCommands/SycVariableCommand.class.st
+++ b/src/SystemCommands-VariableCommands/SycVariableCommand.class.st
@@ -21,6 +21,11 @@ SycVariableCommand class >> canBeExecutedInContext: aToolContext [
 	^aToolContext isVariableSelected
 ]
 
+{ #category : #testing }
+SycVariableCommand class >> isAbstract [
+	^self = SycVariableCommand 
+]
+
 { #category : #execution }
 SycVariableCommand >> prepareFullExecutionInContext: aToolContext [
 	super prepareFullExecutionInContext: aToolContext.


### PR DESCRIPTION
Remove odd logic to define isAbstract as "^self subclasses notEmpty".
It should be always explicit pattern like "^self = MyClass"