### PR TITLE
71-window-variable-of-ComposableCommander-should-not-be-used

### DIFF
--- a/src/SystemCommands-RefactoringSupport/SycRefactoringPreview.class.st
+++ b/src/SystemCommands-RefactoringSupport/SycRefactoringPreview.class.st
@@ -94,7 +94,7 @@ SycRefactoringPreview >> accept [
 	[ self pickedChanges do: [ :change | RBRefactoryChangeManager instance performChange: change ] ] asJob
 		title: 'Refactoring';
 		run.
-	window value delete
+	self window delete
 ]
 
 { #category : #private }
@@ -133,7 +133,7 @@ SycRefactoringPreview >> buildDiffFor: aChange [
 
 { #category : #controlling }
 SycRefactoringPreview >> cancel [
-	window value delete
+	self window delete
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Do not reference #window variable.

Fixes #71